### PR TITLE
Fix typo `associtations` -> `associations`

### DIFF
--- a/cmake/nsis/fileext.nsh
+++ b/cmake/nsis/fileext.nsh
@@ -64,7 +64,7 @@ Call AddCheckedListViewItemWith1SubItem
 !macroend
 
 Function LVPageCreate
-; MessageBox MB_YESNO "Do you want to set file associtations?" IDYES yes
+; MessageBox MB_YESNO "Do you want to set file associations?" IDYES yes
 ;      Abort
 ; yes:
 MessageBox MB_YESNO $(kFileAssocQuestion) IDYES yes

--- a/cmake/nsis/mrv2_translations.nsh
+++ b/cmake/nsis/mrv2_translations.nsh
@@ -1,6 +1,6 @@
 ; -*- coding: utf-8 -*-
 
-LangString kFileAssocQuestion ${LANG_English} "Do you want to set file associtations?"
+LangString kFileAssocQuestion ${LANG_English} "Do you want to set file associations?"
 LangString kFileAssocQuestion ${LANG_Spanish} "¿Quieres establecer asociaciones de archivos?"
 LangString kFileAssocQuestion ${LANG_SpanishInternational} "¿Quieres establecer asociaciones de archivos?"
 


### PR DESCRIPTION
Fix typo in English `associtations` -> `associations` in the installer.