### PR TITLE
Fix command line `-help` second timeline typo `tmeline` -> `timeline`

### DIFF
--- a/mrv2/lib/mrvApp/App.cpp
+++ b/mrv2/lib/mrvApp/App.cpp
@@ -229,7 +229,7 @@ namespace mrv
                  _("Timeline, movie, image sequence, or folder."), true),
              app::CmdLineValueArg<std::string>::create(
                  p.options.fileName[1], "second",
-                 _("Second tmeline, movie, image sequence, or folder."), true),
+                 _("Second timeline, movie, image sequence, or folder."), true),
              app::CmdLineValueArg<std::string>::create(
                  p.options.fileName[2], "third",
                  _("Third timeline, movie, image sequence, or folder."), true)},

--- a/mrv2/po/es.po
+++ b/mrv2/po/es.po
@@ -3405,7 +3405,7 @@ msgstr "Herramienta de Fregado"
 msgid "Search"
 msgstr "Buscar"
 
-msgid "Second tmeline, movie, image sequence, or folder."
+msgid "Second timeline, movie, image sequence, or folder."
 msgstr "Segunda línea de tiempo, película, secuencias de imágenes o carpeta."
 
 msgid "Secondary Display"

--- a/mrv2/po/messages.pot
+++ b/mrv2/po/messages.pot
@@ -3138,7 +3138,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-msgid "Second tmeline, movie, image sequence, or folder."
+msgid "Second timeline, movie, image sequence, or folder."
 msgstr ""
 
 msgid "Secondary Display"


### PR DESCRIPTION
Fix command line `-help` second timeline typo `tmeline` -> `timeline`