### PR TITLE
Fix typos in src/python

### DIFF
--- a/src/python/demos/fltk/bad/browserData.py
+++ b/src/python/demos/fltk/bad/browserData.py
@@ -56,7 +56,7 @@ def main():
 	o_2_1.callback(onOK)
 	o_1_0.label('check_browser.py')
 	o_1_0.end()
-	aBrowser.add("Guiness", "line 1" )  # code
+	aBrowser.add("Guinness", "line 1" )  # code
 	aBrowser.add("Bud", "line 2")  # code
 	aBrowser.add("Coors", "line 3")
 	aBrowser.add("rocky mountain", "line 4")  # code

--- a/src/python/demos/fltk/bad/subwindow.py
+++ b/src/python/demos/fltk/bad/subwindow.py
@@ -137,7 +137,7 @@ window.add(subwindow)
 
 fb = Fl_Box(FL_NO_BOX,0,0,400,100,
 	     "A child Fl_Window with children of it's own may "
-	     "be useful for imbedding controls into a GL or display "
+	     "be useful for embedding controls into a GL or display "
 	     "that needs a different visual.  There are bugs with the "
 	     "origins being different between drawing and events, "
 	     "which I hope I have solved."

--- a/src/python/demos/fltk/browser_cols.py
+++ b/src/python/demos/fltk/browser_cols.py
@@ -60,7 +60,7 @@ def main():
 	btn.callback(onOK)
 	win.label('check_browser.py')
 	win.end()
-	aBrowser.add("Guiness\tline 1", "line 1" )  # code
+	aBrowser.add("Guinness\tline 1", "line 1" )  # code
 	aBrowser.add("Bud\tline 2", "line 2")  # code
 	aBrowser.add("Coors\tline 3", "line 3")
 	aBrowser.add("rocky mountain\tline 4", "line 4")  # code

--- a/src/python/demos/fltk/check_browser.py
+++ b/src/python/demos/fltk/check_browser.py
@@ -65,7 +65,7 @@ def main():
     o_2_1.callback(onOK)
     o_1_0.label('check_browser.py')
     o_1_0.end()
-    aCheckBrowser.add("Guiness", 1)  # code
+    aCheckBrowser.add("Guinness", 1)  # code
     aCheckBrowser.add("Bud")  # code
     aCheckBrowser.add("Coors")  # code
     aCheckBrowser.add("Grimbergen", 1)  # code

--- a/src/python/demos/fltk/doublebuffer.py
+++ b/src/python/demos/fltk/doublebuffer.py
@@ -2,7 +2,7 @@
 # the Fast Light Tool Kit (pyFLTK).
 #
 # This demo shows how double buffering helps, by drawing the
-# window in a particularily bad way.
+# window in a particularly bad way.
 #
 # The single-buffered window will blink as it updates.  The
 # double buffered one will not.  It will take just as long

--- a/src/python/demos/fltk/message.py
+++ b/src/python/demos/fltk/message.py
@@ -30,10 +30,10 @@
 
 from fltk import *
 
-fl_message("Spelling check sucessfull, %d errors found with %f confidence" \
+fl_message("Spelling check successful, %d errors found with %f confidence" \
 	%(1002, 100*(15/77.0)))
 
-fl_alert("Quantum fluctuations in the space-time continuim detected, "
+fl_alert("Quantum fluctuations in the space-time continuum detected, "
 	   "you have %f seconds to comply."% 10.0)
 
 print(f"fl_ask returned {fl_ask('Do you really want to continue?')}")

--- a/src/python/demos/fltk/message_de.py
+++ b/src/python/demos/fltk/message_de.py
@@ -35,10 +35,10 @@ fl_yes_set("Ja")
 fl_no_set("Nein")
 fl_cancel_set("Abbrechen")
 
-fl_message("Spelling check sucessfull, %d errors found with %f confidence" \
+fl_message("Spelling check successful, %d errors found with %f confidence" \
 	%(1002, 100*(15/77.0)))
 
-fl_alert("Quantum fluctuations in the space-time continuim detected, "
+fl_alert("Quantum fluctuations in the space-time continuum detected, "
 	   "you have %f seconds to comply."% 10.0)
 
 print(f"fl_ask returned {fl_ask('Do you really want to continue?')}")

--- a/src/python/demos/fltk/unittests.py
+++ b/src/python/demos/fltk/unittests.py
@@ -120,7 +120,7 @@ def fl_point_test():
     page = beginTestPage(
             """testing the fl_point call\n
             You should see four pixels each in black, red, green and blue. 
-            Make sure that pixels are not anti-aliased (blured across multiple pixels)!"""  )
+            Make sure that pixels are not anti-aliased (blurred across multiple pixels)!"""  )
     pt = PointTest(20, 140, 100, 100)
     page.end()
     return pt
@@ -371,7 +371,7 @@ def fl_circle_test():
         "testing int drawing of circles and ovals (fl_arc, fl_pie)\n"
         "No red lines should be visible. "
         "If you see bright red pixels, the circle drawing alignment is off. "
-        "If you see dark red pixels, your syste supports anti-aliasing "
+        "If you see dark red pixels, your system supports anti-aliasing "
         "which should be of no concern. "
         "The green rectangles should not be touched by circle drawings."
         )


### PR DESCRIPTION
Found via codespell