### PR TITLE
Fix typos in src/lib/mrvWidgets

### DIFF
--- a/src/lib/mrvWidgets/mrvButton.h
+++ b/src/lib/mrvWidgets/mrvButton.h
@@ -9,7 +9,7 @@
 namespace mrv
 {
 
-    //! Button class that changes cursor and hilights the button when hover it.
+    //! Button class that changes cursor and highlights the button when hover it.
     class Button : public Fl_Button
     {
         Fl_Color default_color;

--- a/src/lib/mrvWidgets/mrvCollapsibleGroup.cpp
+++ b/src/lib/mrvWidgets/mrvCollapsibleGroup.cpp
@@ -120,7 +120,7 @@ namespace mrv
             w - (GROUP_MARGIN * 2), // width same as group within margin
             10);                    // changes when child add()ed
 
-        // end() _contents; we dont' want it to begin() sucking up child widgets
+        // end() _contents; we don't want it to begin() sucking up child widgets
         // on return
         _contents->end();
         Fl_Group::end();

--- a/src/lib/mrvWidgets/mrvDropWindow.cpp
+++ b/src/lib/mrvWidgets/mrvDropWindow.cpp
@@ -36,7 +36,7 @@ namespace mrv
         if (dock)
         {
             // Did the drop happen on us?
-            // Get our co-ordinates
+            // Get our coordinates
             int ex = x_root() + dock->x();
             int ey = y_root() + dock->y();
             int ew = dock->w();

--- a/src/lib/mrvWidgets/mrvPanelGroup.cpp
+++ b/src/lib/mrvWidgets/mrvPanelGroup.cpp
@@ -312,7 +312,7 @@ namespace mrv
     }
 
     // Constructors for docked/floating window
-    // WITH x, y co-ordinates
+    // WITH x, y coordinates
     PanelGroup::PanelGroup(
         DockGroup* dk, int floater, int X, int Y, int W, int H,
         const char* lbl) :

--- a/src/lib/mrvWidgets/mrvPreferencesUI.fl
+++ b/src/lib/mrvWidgets/mrvPreferencesUI.fl
@@ -128,7 +128,7 @@ If you try to open several mrv2s with different images, all these images will be
                 }
                 Fl_Check_Button uiPrefsAutoFitImage {
                   label {Auto Refit Image}
-                  tooltip {When selected, mrv2 will apply a fit image operation on each video played.  This effectly means the video will be resized automatically based on the size of the window.} xywh {317 161 25 25} box UP_BOX down_box DOWN_BOX value 1 align 8
+                  tooltip {When selected, mrv2 will apply a fit image operation on each video played.  This effectively means the video will be resized automatically based on the size of the window.} xywh {317 161 25 25} box UP_BOX down_box DOWN_BOX value 1 align 8
                 }
                 Fl_Check_Button uiPrefsRaiseOnEnter {
                   label {Raise on Enter}
@@ -1462,7 +1462,7 @@ v->uiOCIO_Display_View->do_callback();}
                 }
                 Fl_Choice uiPrefsColorAccuracy {
                   label {Color Buffers' Accuracy} open
-                  tooltip {Color Buffers can be Float, Half Float, Fast or Automatic.  Float preserves all float information, Half Float preserves most float information and Fast works in 8-bits.  Automatic selects the accuracy baed on image depth.} xywh {511 167 140 25} down_box BORDER_BOX align 132 textcolor 32
+                  tooltip {Color Buffers can be Float, Half Float, Fast or Automatic.  Float preserves all float information, Half Float preserves most float information and Fast works in 8-bits.  Automatic selects the accuracy based on image depth.} xywh {511 167 140 25} down_box BORDER_BOX align 132 textcolor 32
                   class {mrv::Choice}
                 } {
                   MenuItem {} {

--- a/src/lib/mrvWidgets/mrvSecondaryWindow.h
+++ b/src/lib/mrvWidgets/mrvSecondaryWindow.h
@@ -21,7 +21,7 @@ namespace mrv
         SecondaryWindow(ViewerUI*);
         ~SecondaryWindow();
 
-        //! Save the settings for the vindow (if it is visible or not)
+        //! Save the settings for the window (if it is visible or not)
         void save() const;
 
         //! Get the main window

--- a/src/lib/mrvWidgets/mrvSlider.cpp
+++ b/src/lib/mrvWidgets/mrvSlider.cpp
@@ -502,7 +502,7 @@ namespace mrv
             return 1;
         case FL_KEYBOARD:
             // Only arrows in the correct direction are used.  This allows the
-            // opposite arrows to be used to navigate between a set of parellel
+            // opposite arrows to be used to navigate between a set of parallel
             // sliders.
             switch (Fl::event_key())
             {

--- a/src/lib/mrvWidgets/mrvVersion.cpp
+++ b/src/lib/mrvWidgets/mrvVersion.cpp
@@ -466,7 +466,7 @@ namespace mrv
         f = new FormatInfo(true, false, false, "DRF", "mrv2", "RAW Image File");
         formats.push_back(f);
         f = new FormatInfo(
-            true, false, false, "DSC", "mrv2", "Digitial Still RAW Camera");
+            true, false, false, "DSC", "mrv2", "Digital Still RAW Camera");
         formats.push_back(f);
         f = new FormatInfo(
             true, false, false, "ERF", "mrv2", "Epson RAW Camera");


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,*.pot,*.svg,./docs/sphinx/es,./src/docs/es,./src/docs/en/searchindex.js,./src/docs/HISTORY.md" -L aci,afile,childs,outlow,ot,substract,te,ue src/lib/mrvWidgets/`